### PR TITLE
Replace placeholder with actual image in home page hero section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <section class="hero" id="home-hero-section">
             <div class="hero-content-split">
                 <div class="hero-image-column">
-                    <div class="image-placeholder" style="width:100%; height:400px; background-color:#ddc; border:1px solid #cab; display:flex; align-items:center; justify-content:center; font-family: sans-serif; color: #987;">Refurbished Dresser Image Placeholder</div>
+                    <img src="https://github.com/gpudewell/test/blob/main/dresser.png?raw=true" alt="Refurbished old-style dresser">
                 </div>
                 <div class="hero-text-column">
                     <h1>Revitalized Vintage Furniture With Modern Charm.</h1>

--- a/style.css
+++ b/style.css
@@ -135,19 +135,18 @@ nav ul li a.active {
     /* max-width: 40%; If using flex-grow/shrink instead of basis */
 }
 
+#home-hero-section .hero-image-column img {
+    max-width: 100%;
+    height: auto;
+    display: block; /* Removes extra space below inline images */
+    border-radius: 8px; /* Optional: adds slightly rounded corners to the image */
+}
+
 #home-hero-section .hero-text-column {
     flex-basis: 55%;
     /* max-width: 55%; If using flex-grow/shrink instead of basis */
 }
 
-/* Placeholder styling is inline in HTML for now. If it were a real image: */
-/*
-#home-hero-section .hero-image-column img {
-    max-width: 100%;
-    height: auto;
-    display: block;
-}
-*/
 
 /* General .hero h1 and .hero p styling */
 .hero h1 {


### PR DESCRIPTION
This commit updates the hero section on `index.html` (`#home-hero-section`) by replacing the div-based image placeholder with an `<img>` tag.

Key changes:
- `index.html`: The `.hero-image-column` now contains an `<img>` tag pointing to the `dresser.png` image hosted on GitHub via its raw URL. An appropriate alt attribute has been added.
- `style.css`: Added styles for `#home-hero-section .hero-image-column img` to ensure the image is responsive (`max-width: 100%; height: auto;`) and displays correctly (e.g., `display: block;`). An optional `border-radius` was also included.